### PR TITLE
fix log folder permissions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -94,10 +94,11 @@ ynh_add_nginx_config
 
 ### systemd
 
-mkdir -p /var/log/$app
-touch /var/log/$app/$app-api.log
-touch /var/log/$app/$app-proxy.log
-chown -R $app: /var/log/$app
+mkdir -p "/var/log/$app"
+touch "/var/log/$app/$app-api.log"
+touch "/var/log/$app/$app-proxy.log"
+chown -R "$app:" "/var/log/$app"
+chmod 640 "/var/log/$app"
 
 ynh_use_logrotate --logfile="/var/log/$app/$app-api.log"
 ynh_use_logrotate --logfile="/var/log/$app/$app-proxy.log"

--- a/scripts/restore
+++ b/scripts/restore
@@ -46,8 +46,9 @@ systemctl enable $app-proxy.service --quiet
 #=================================================
 ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1
 
-mkdir -p /var/log/$app
-chown -R $app:root /var/log/$app
+mkdir -p "/var/log/$app"
+chown -R "$app:root" "/var/log/$app"
+chmod 640 "/var/log/$app"
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -17,6 +17,8 @@ upgrade_type=$(ynh_check_app_version_changed)
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
 
+chmod 640 "/var/log/$app"
+
 #=================================================
 # STOP SYSTEMD SERVICE
 #=================================================


### PR DESCRIPTION
```bash
logrotate /etc/logrotate.d/piped
error: skipping "/var/log/piped/piped-api.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
error: skipping "/var/log/piped/piped-proxy.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
chmod 640 /var/log/piped/
logrotate /etc/logrotate.d/piped
```

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
