### PR TITLE
Remove usages of `sed`

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -53,7 +53,7 @@ popd
 
 mv $install_dir/build/dist $install_dir
 pushd $install_dir/dist
-    sed -i s/pipedapi.kavin.rocks/"$domain\\/api"/g assets/*
+    ynh_replace_string --match_string="pipedapi\.kavin\.rocks" -replace_string="$domain\\/api" --target_file="assets/*"
 popd
 chown -R $app:www-data "$install_dir/dist"
 chmod -R 755 "$install_dir/dist"


### PR DESCRIPTION
## Problem

- Linter complains

## Solution

- Use `ynh_replace_string`

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
